### PR TITLE
Force /usr/bin/sed usage in setup script

### DIFF
--- a/boilerplate-setup.sh
+++ b/boilerplate-setup.sh
@@ -40,7 +40,7 @@ if [[ -z "$1" ]] ; then
 fi
 
 pascalCaseAfter=$1
-snakeCaseAfter=$(echo $pascalCaseAfter | sed 's/\(.\)\([A-Z]\)/\1_\2/g' | tr '[:upper:]' '[:lower:]')
+snakeCaseAfter=$(echo $pascalCaseAfter | /usr/bin/sed 's/\(.\)\([A-Z]\)/\1_\2/g' | tr '[:upper:]' '[:lower:]')
 kebabCaseAfter=$(echo $snakeCaseAfter | tr '_' '-')
 
 # -----------------------------------------------------------------------------
@@ -72,15 +72,15 @@ echo ""
 
 header "Replacing boilerplate identifiers in content"
 for file in $content; do
-  run sed -i "''" "s/$snakeCaseBefore/$snakeCaseAfter/g" $file
-  run sed -i "''" "s/$kebabCaseBefore/$kebabCaseAfter/g" $file
-  run sed -i "''" "s/$pascalCaseBefore/$pascalCaseAfter/g" $file
+  run /usr/bin/sed -i "''" "s/$snakeCaseBefore/$snakeCaseAfter/g" $file
+  run /usr/bin/sed -i "''" "s/$kebabCaseBefore/$kebabCaseAfter/g" $file
+  run /usr/bin/sed -i "''" "s/$pascalCaseBefore/$pascalCaseAfter/g" $file
 done
 success "Done!\n"
 
 header "Replacing boilerplate identifiers in file and directory paths"
 for path in $paths; do
-  run mv $path $(echo $path | sed "s/$snakeCaseBefore/$snakeCaseAfter/g" | sed "s/$kebabCaseBefore/$kebabCaseAfter/g" | sed "s/$pascalCaseBefore/$pascalCaseAfter/g")
+  run mv $path $(echo $path | /usr/bin/sed "s/$snakeCaseBefore/$snakeCaseAfter/g" | /usr/bin/sed "s/$kebabCaseBefore/$kebabCaseAfter/g" | /usr/bin/sed "s/$pascalCaseBefore/$pascalCaseAfter/g")
 done
 success "Done!\n"
 


### PR DESCRIPTION
Sometimes developers have installed GNU `sed` as their primary `sed` command. However, it doesn’t work with how we pass arguments in the setup script.

This pull requests forces the setup script to use `/usr/bin/sed`.