### PR TITLE
Do not freeze patch version for Node and NPM requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - 11.10.0
+  - 11.13
 
 dist: trusty
 
@@ -10,8 +10,7 @@ cache:
     - node_modules
 
 install:
-  - npm install -g npm@6.8.0
-  - npm install
+  - npm ci
 
 script:
   - ./scripts/ci-check.sh

--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -22,8 +22,8 @@
 
 ## 🚧 Dependencies
 
-- Node.js (`10.11.0`)
-- NPM (`6.4.1`)
+- Node.js (`~> 11.13`)
+- NPM (`~> 6.7`)
 
 ## 🏎 Kickstart
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14-alpine
+FROM node:11.13-alpine
 
 WORKDIR /opt/app
 
@@ -6,7 +6,9 @@ RUN npm install -g serve
 
 COPY package.json package-lock.json ./
 
-RUN npm install
+COPY scripts ./scripts
+
+RUN npm ci --no-audit --no-color --unsafe-perm
 
 COPY . .
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ lint: lint-prettier lint-tslint lint-stylelint lint-stylelint-components ## Run 
 
 .PHONY: lint-prettier
 lint-prettier:
-	npx prettier -l '{src,typings,__mocks__}/**/*.{js,ts,tsx}' '**/*.md'
+	npx prettier -l '{src,typings,__mocks__,scripts}/**/*.{js,ts,tsx}' '**/*.md'
 
 .PHONY: lint-tslint
 lint-tslint:
@@ -96,7 +96,7 @@ format: format-prettier ## Run formatting tools on the code
 
 .PHONY: format-prettier
 format-prettier:
-	npx prettier --write '{src,typings,__mocks__}/**/*.{js,ts,tsx}' '**/*.md'
+	npx prettier --write '{src,typings,__mocks__,scripts}/**/*.{js,ts,tsx}' '**/*.md'
 
 .PHONY: typecheck
 typecheck:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "engine-strict": true,
   "engines": {
-    "node": "11.10.0",
-    "npm": "6.8.0"
+    "node": "~> 11.13",
+    "npm": "~> 6.7"
   },
   "dependencies": {
     "@emotion/core": "^10.0.7",
@@ -33,6 +33,7 @@
     "test": "TZ=UTC mirego-react-scripts test",
     "enforce-engine-versions": "./scripts/enforce-engine-versions.js",
     "preinstall": "npm run enforce-engine-versions",
+    "postinstall": "npm run enforce-engine-versions",
     "prestart": "npm run enforce-engine-versions",
     "prestest": "npm run enforce-engine-versions"
   },

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -36,8 +36,11 @@ run make test-coverage
 header "Run typecheck…"
 run make typecheck
 
-header "Build…"
+header "Build application…"
 run make build-app
+
+header "Build Docker image…"
+run make build
 
 if [ ${error_status} -ne 0 ]; then
   echo "\n\n${YELLOW}▶▶ One of the checks ${RED_BOLD}failed${YELLOW}. Please fix it before committing.${NO_COLOR}"

--- a/scripts/enforce-engine-versions.js
+++ b/scripts/enforce-engine-versions.js
@@ -4,22 +4,45 @@
 /* eslint-disable no-console */
 
 let exitStatus = 0;
+let semver;
 
-const {node: expectedNodeVersion, npm: expectedNpmVersion} = require('../package.json').engines;
+try {
+  semver = require('semver');
+} catch {
+  // The `semver` might not be available since we run this
+  // script as a `preinstall` hook.
+  console.info(
+    'Skipping “enforce-engine-versions” script because `semver` module is not available.'
+  );
+  process.exit(exitStatus);
+}
+
+const {
+  node: expectedNodeVersion,
+  npm: expectedNpmVersion
+} = require('../package.json').engines;
 const actualNodeVersion = process.versions.node;
-const actualNpmVersion = require('child_process').execSync('npm -v').toString().replace(/\n/, '');
+
+const actualNpmVersion = require('child_process')
+  .execSync('npm -v')
+  .toString()
+  .replace(/\n/, '');
 
 console.info(`Node.js ${actualNodeVersion}`);
 console.info(`NPM ${actualNpmVersion}`);
 console.info('');
 
-if (expectedNodeVersion !== actualNodeVersion) {
-  console.error(`You are using Node.js ${actualNodeVersion} but the required version specified in package.json is ${expectedNodeVersion}`);
+if (!semver.satisfies(actualNodeVersion, expectedNodeVersion)) {
+  console.error(
+    `You are using Node.js ${actualNodeVersion} but the required version specified in package.json is ${expectedNodeVersion}`
+  );
   exitStatus = 1;
 }
 
-if (expectedNpmVersion !== actualNpmVersion) {
-  console.error(`You are using NPM ${actualNpmVersion} but the required version specified in package.json is ${expectedNpmVersion}`);
+if (!semver.satisfies(actualNpmVersion, expectedNpmVersion)) {
+  console.error(
+    `You are using NPM ${actualNpmVersion} but the required version specified in package.json is ${expectedNpmVersion}`
+  );
   exitStatus = 1;
 }
 


### PR DESCRIPTION
Like we did in https://github.com/mirego/elixir-boilerplate/pull/15, we now require `node ~> 11.13` (not `node = 11.10.0`) and `npm ~> 6.7` (not `npm = 6.8.0`).