### PR TITLE
Do not make APP_NAME and APP_VERSION customizable in “make” commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Configuration
 # -------------
 
-APP_NAME ?= `grep -m1 name package.json | awk -F: '{ print $$2 }' | sed 's/[ ",]//g'`
-APP_VERSION ?= `grep -m1 version package.json | awk -F: '{ print $$2 }' | sed 's/[ ",]//g'`
+APP_NAME = `grep -m1 name package.json | awk -F: '{ print $$2 }' | sed 's/[ ",]//g'`
+APP_VERSION = `grep -m1 version package.json | awk -F: '{ print $$2 }' | sed 's/[ ",]//g'`
 GIT_REVISION ?= `git rev-parse HEAD`
 DOCKER_IMAGE_TAG ?= latest
 DOCKER_REGISTRY ?=


### PR DESCRIPTION
We don’t need to customize these variables when running `make` commands — the app name and version should always be extracted from `package.json`.