### PR TITLE
Build Docker image before “dev-start” Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build-app:
 # -------------------
 
 .PHONY: dev-start
-dev-start: ## Start every service of in the Docker Compose environment
+dev-start: build ## Start every service of in the Docker Compose environment
 	docker-compose up
 
 .PHONY: dev-stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 version: '3.3'
 services:
   application:
+    image: react-boilerplate
     container_name: react-boilerplate
     env_file: .env.development
-    build:
-      context: .
-      dockerfile: Dockerfile
     volumes:
       - '.:/usr/src/app'
       - '/usr/src/app/node_modules'


### PR DESCRIPTION
We now make sure that `make build` is called when running our Docker Compose setup.