### PR TITLE
Remove Docker Compose make targets

### DIFF
--- a/BOILERPLATE_README.md
+++ b/BOILERPLATE_README.md
@@ -112,4 +112,4 @@ Each deployment is made from a Git tag. The codebase version is managed with [`i
 
 ### Container
 
-A Docker image running a Node.js server can be created with `make build`, tested with `make services-start` and pushed to a registry with `make push`.
+A Docker image running a Node.js server can be created with `make build`, tested with `docker-compose up application` and pushed to a registry with `make push`.

--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,3 @@ lint-scripts:
 lint-styles:
 	npx stylelint --config .stylelintrc.json $(STYLES_PATTERN)
 	npx stylelint --config .stylelintrc-components.json $(SCRIPTS_PATTERN)
-
-# Service container targets
-# -------------------------
-
-.PHONY: services-start
-services-start: build ## Start every service in the Docker Compose environment
-	docker-compose up
-
-.PHONY: services-stop
-services-stop: ## Stop every service in the Docker Compose environment
-	docker-compose down


### PR DESCRIPTION
We were only making a single reference to the `services-start` target in the README.md — and it was to _test_ the Docker image.

Now we explictely tell developers to use `docker-compose up application` if they want to use Docker Compose to test the image they just built 😄 