### PR TITLE
Improve Docker-related environment variables in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - 11.13
+  - 12.14
 
 dist: trusty
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Since it is a boilerplate project, there are technically no official (versioned) _releases_. Therefore, the `master` branch should always be stable and usable.
 
+## 2020-01-22
+
+### Updated
+
+- Improve Docker-related environment variables in Makefile (#12)
+
 ## 2019-10-18
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.13-alpine
+FROM node:12.14.1-alpine3.9
 
 WORKDIR /opt/app
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2019, Mirego
+Copyright (c) 2018-2020, Mirego
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@
 APP_NAME = `grep -m1 name package.json | awk -F: '{ print $$2 }' | sed 's/[ ",]//g'`
 APP_VERSION = `grep -m1 version package.json | awk -F: '{ print $$2 }' | sed 's/[ ",]//g'`
 GIT_REVISION = `git rev-parse HEAD`
-DOCKER_IMAGE_TAG ?= latest
+DOCKER_IMAGE_TAG ?= $(APP_VERSION)
 DOCKER_REGISTRY ?=
+DOCKER_LOCAL_IMAGE = $(APP_NAME):$(DOCKER_IMAGE_TAG)
+DOCKER_REMOTE_IMAGE = $(DOCKER_REGISTRY)/$(DOCKER_LOCAL_IMAGE)
 
 # Linter and formatter configuration
 # ----------------------------------
@@ -38,6 +40,12 @@ header:
 	@echo ""
 	@printf "\033[33m%-23s\033[0m" "DOCKER_REGISTRY"
 	@printf "\033[35m%s\033[0m" $(DOCKER_REGISTRY)
+	@echo ""
+	@printf "\033[33m%-23s\033[0m" "DOCKER_LOCAL_IMAGE"
+	@printf "\033[35m%s\033[0m" $(DOCKER_LOCAL_IMAGE)
+	@echo ""
+	@printf "\033[33m%-23s\033[0m" "DOCKER_REMOTE_IMAGE"
+	@printf "\033[35m%s\033[0m" $(DOCKER_REMOTE_IMAGE)
 	@echo "\n"
 
 .PHONY: targets
@@ -51,12 +59,12 @@ targets:
 
 .PHONY: build
 build: ## Build the Docker image
-	docker build --rm --tag $(APP_NAME):$(DOCKER_IMAGE_TAG) .
+	docker build --build-arg APP_NAME=$(APP_NAME) --build-arg APP_VERSION=$(APP_VERSION) --rm --tag $(DOCKER_LOCAL_IMAGE) .
 
 .PHONY: push
-push: ## Push the Docker image
-	docker tag $(APP_NAME):$(DOCKER_IMAGE_TAG) $(DOCKER_REGISTRY)/$(APP_NAME):$(DOCKER_IMAGE_TAG)
-	docker push $(DOCKER_REGISTRY)/$(APP_NAME):$(DOCKER_IMAGE_TAG)
+push: ## Push the Docker image to the registry
+	docker tag $(DOCKER_LOCAL_IMAGE) $(DOCKER_REMOTE_IMAGE)
+	docker push $(DOCKER_REMOTE_IMAGE)
 
 # Development targets
 # -------------------

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This boilerplate comes with batteries included, you’ll find:
 
 ## License
 
-React Boilerplate is © 2018-2019 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/react-boilerplate/blob/master/LICENSE.md) file.
+React Boilerplate is © 2018-2020 [Mirego](https://www.mirego.com) and may be freely distributed under the [New BSD license](http://opensource.org/licenses/BSD-3-Clause). See the [`LICENSE.md`](https://github.com/mirego/react-boilerplate/blob/master/LICENSE.md) file.
 
 The science logo is based on [this lovely icon by Igé Maulana](https://thenounproject.com/term/science/2089589), from The Noun Project. Used under a [Creative Commons BY 3.0](http://creativecommons.org/licenses/by/3.0/) license.
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "engine-strict": true,
   "engines": {
-    "node": "~11.13",
-    "npm": "~6.7"
+    "node": "~12.14",
+    "npm": "~6.13"
   },
   "dependencies": {
     "@emotion/core": "^10.0.7",


### PR DESCRIPTION
We now have simpler and clearer Docker-related environment variables in our `Makefile`

```bash
$ DOCKER_REGISTRY=gcr.io/foo make

# Environment
# ---------------------------------------------------------------
# APP_NAME               react-boilerplate
# APP_VERSION            0.0.1
# GIT_REVISION           2212a9fe9ab22bd1994cfc89dc002a70afb33219
# DOCKER_IMAGE_TAG       0.0.1
# DOCKER_REGISTRY        gcr.io/foo
# DOCKER_LOCAL_IMAGE     react-boilerplate:0.0.1
# DOCKER_REMOTE_IMAGE    gcr.io/foo/react-boilerplate:0.0.1
```