### PR TITLE
Add “boilerplate projects” blog post in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
   <a href="https://travis-ci.com/mirego/react-boilerplate"><img src="https://travis-ci.com/mirego/react-boilerplate.svg?branch=master" /></a>
 </div>
 
+## Introduction
+
+To learn more about _why_ we created and maintain this boilerplate project, read our [blog post](https://shift.mirego.com/en/boilerplate-projects).
+
 ## Content
 
 This boilerplate comes with batteries included, you’ll find:


### PR DESCRIPTION
## 📖 Description

Now that we have a published blog post that explain the reasoning behind our boilerplate projects, let’s reference it in them.